### PR TITLE
Store all favorites data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,19 @@ Music Tinder Web Application Project - Swipe on song snippets to create a discov
 
 To get started on development follow these instructions:
 
+[Register your App with the Spotify API](https://developer.spotify.com/documentation/web-api/tutorials/getting-started#create-an-app)
+Then find your Client ID and Client Secret on the settings page
+
 Install Dependencies
 
 1) `cd Spotify Tinder`
 2) `npm install`
 3) In the current directory, create a `.env` file with the contents:
 
-```json
+```
 JSONSECRETKEY = <UUID Generated Value>
+SPOTIFYCLIENTID = <Spotify Client ID>
+SPOTIFYCLIENTSECRET = <Spotify Client Secret>
 ```
 You can generate your own UUID [here](https://www.uuidgenerator.net/).
 
@@ -37,7 +42,7 @@ For the final project assignment, we must complete the following:
 Here's how we plan on doing this:
 
 1) The main part of the frontend will be a tinder-like scrolling feature where you will have "swipe right/like" and "swipe left/dislike" buttons. Upon swiping another song snippet will be loaded in. This should satisfy the event-driver and interactive portions.
-2) The backend will need to store user log-ins. We can keep track of users liked and disliked songs so we don't send them a song they've heard before on another session. We can also store session playlists for each user. A session playlist will consist of all the liked songs for that session so the user can go back in on spotify and listen to them.
+2) The backend will need to store user log-ins. We can store liked song playlists for each user. A liked song playlist will consist of all the songs that the users has liked so the user can find them on spotify later and listen to them.
 3) The third party API we plan on using is the Spotify API to get the song information/snippets. The route we will most likely need to use for this is `GET /tracks/{id}`. [Route Documentation](https://developer.spotify.com/documentation/web-api/reference/get-track)
 4) We plan on having a user sign-in component so users can see past session playlists and possibly link directly into their spotify account
 5) The user experience will mostly be in the swiping page, which should have a nice, pleasing design
@@ -56,7 +61,8 @@ The swipe page will consist of a center display, where the cover art, artist nam
 
 ### playlist_page
 
-The playlist page will house all of the users liked playlists. Users should be able to port their liked playlists to actual spotify playlists that they can save to their account.
+The playlist page will house all of the users liked playlists. 
+> This may be added later: Users should be able to port their liked playlists to actual spotify playlists that they can save to their account.
 
 ## Technical Details
 

--- a/Spotify Tinder/src/server/db_setup.js
+++ b/Spotify Tinder/src/server/db_setup.js
@@ -6,6 +6,6 @@ await db.run('DROP TABLE IF EXISTS Favorites')
 
 await db.run(`CREATE TABLE IF NOT EXISTS Users (id INTEGER PRIMARY KEY, userName varchar(50) NOT NULL, password varchar(256) NOT NULL)`);
 
-await db.run('CREATE TABLE IF NOT EXISTS Favorites (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, song_id varchar(256) NOT NULL, FOREIGN KEY (user_id) REFERENCES Users(id))');
+await db.run('CREATE TABLE IF NOT EXISTS Favorites (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, song_id varchar(256) NOT NULL, title TEXT, artist TEXT, album_url TEXT, FOREIGN KEY (user_id) REFERENCES Users(id))');
 
 await db.close();

--- a/Spotify Tinder/src/server/favorites.ts
+++ b/Spotify Tinder/src/server/favorites.ts
@@ -4,22 +4,28 @@ export class Favorites {
     #id: number;
     #user_id: number;
     #favorite_id: string; // Spotify song ID
+    #title: string;
+    #artists: string;
+    #album_url: string;
 
-    constructor(id: number, user_id: number, favorite: string) {
+    constructor(id: number, user_id: number, favorite: string, title: string = "", artists: string = "", album_url: string = "") {
         this.#id = id;
         this.#user_id = user_id;
         this.#favorite_id = favorite;
+        this.#title = title;
+        this.#artists = artists;
+        this.#album_url = album_url;
     }
 
-    static async add_favorite(user_id: number, favorite: string): Promise<boolean> {
+    static async add_favorite(user_id: number, favorite_id: string, title: string = "", artists: string = "", album_url: string = ""): Promise<boolean> {
         /**
          * Add a song id to the user's favorite list
          * 
-         * @returns Promise<boolean> if adding succeeded
+         * @return Promise<boolean> if adding succeeded
          */
         // TODO: Make sure favorite is not a duplicate for the user
         try {
-            await db.run('INSERT INTO Favorites VALUES (NULL, ?, ?)', user_id, favorite);
+            await db.run('INSERT INTO Favorites VALUES (NULL, ?, ?, ?, ?, ?)', user_id, favorite_id, title, artists, album_url);
             return true;
         } catch (e) {
             return false;

--- a/Spotify Tinder/src/server/favorites.ts
+++ b/Spotify Tinder/src/server/favorites.ts
@@ -41,7 +41,7 @@ export class Favorites {
          */
         try {
             let result = await db.all("SELECT * FROM Favorites WHERE user_id = ?", user_id);
-            return result.map((row: any) => new Favorites(row.id, row.user_id, row.song_id)).sort((a: Favorites, b: Favorites) => b.#id - a.#id);
+            return result.map((row: any) => new Favorites(row.id, row.user_id, row.song_id, row.title, row.artist, row.album_url)).sort((a: Favorites, b: Favorites) => b.#id - a.#id);
         } catch (e) {
             return null;
         }
@@ -74,14 +74,16 @@ export class Favorites {
         return favorites.map((val: any) => val.#favorite_id).slice(0, 4);
     }
 
-    to_json(song: any) {
+    to_json() {
         /**
          * Converts object to JSON without the user_id field
          */
         return {
             "id": this.#id,
             "song_id": this.#favorite_id,
-            "song": song
+            "title": this.#title,
+            "artists": this.#artists,
+            "song_url": this.#album_url
         };
     }
 

--- a/Spotify Tinder/src/server/main.ts
+++ b/Spotify Tinder/src/server/main.ts
@@ -129,30 +129,18 @@ router.get("/get-next-tracks", verifyJWT, updateToken, async (req: any, res) => 
 
 // Routes for Favorites Storage
 
-router.get("/favorites", verifyJWT, updateToken, async (req: any, res) => {
+router.get("/favorites", verifyJWT, async (req: any, res) => {
   /**
    * Gets a list of Favorites, ordered by most recently added by their id
    * 
-   * @returns {id: number, song_id: string, "title": string, "artists": string, "song_url": string}[] list of json objects, artists comma separated list
+   * @returns {id: number, song_id: string, title: string, artists: string, song_url: string}[] list of json objects, artists comma separated list
    */
   let favorites: Favorites[] | null = await Favorites.get_user_favorites(req.userId);
   if (favorites == null) {
     return res.status(500).send("Internal Server Error.");
   }
   
-  let ids = favorites.reduce((acc: string, val: Favorites) => acc += val.song_id + ",", "").slice(0, -1);
-  const response = await fetch("https://api.spotify.com/v1/tracks?ids=" + ids, {
-    headers: {
-      Authorization: 'Bearer ' + curr_token
-    }
-  });
-
-  if (!response.ok) {
-    return res.status(500).send("Internal Server Error.");
-  }
-
-  let songs = (await response.json()).tracks;
-  return res.json(favorites.map((val, i) => val.to_json(songs[i])));
+  res.json(favorites.map(fav => fav.to_json()));
 });
 
 router.post("/favorite", verifyJWT, async (req: any, res) => {

--- a/Spotify Tinder/src/server/main.ts
+++ b/Spotify Tinder/src/server/main.ts
@@ -81,7 +81,7 @@ router.get("/get-track/:id", verifyJWT, updateToken, async (req, res) => {
   return res.json(await response.json());
 });
 
-router.get("/get-next-tracks", verifyJWT, updateToken, async (req, res) => {
+router.get("/get-next-tracks", verifyJWT, updateToken, async (req: any, res) => {
   /**
    * Gets the track info of the next 20 tracks to display on the tinder-like feed
    * ! Do not assume that you will get 20 tracks, there may be less!!
@@ -129,17 +129,17 @@ router.get("/get-next-tracks", verifyJWT, updateToken, async (req, res) => {
 
 // Routes for Favorites Storage
 
-router.get("/favorites", verifyJWT, updateToken, async (req, res) => {
+router.get("/favorites", verifyJWT, updateToken, async (req: any, res) => {
   /**
    * Gets a list of Favorites, ordered by most recently added by their id
    * 
-   * @returns {id: number, song_id: string, song: Song_obj}[] list of json objects
+   * @returns {id: number, song_id: string, "title": string, "artists": string, "song_url": string}[] list of json objects, artists comma separated list
    */
   let favorites: Favorites[] | null = await Favorites.get_user_favorites(req.userId);
   if (favorites == null) {
     return res.status(500).send("Internal Server Error.");
   }
-  // TODO: Need to make a request for every 100 songs
+  
   let ids = favorites.reduce((acc: string, val: Favorites) => acc += val.song_id + ",", "").slice(0, -1);
   const response = await fetch("https://api.spotify.com/v1/tracks?ids=" + ids, {
     headers: {
@@ -155,9 +155,19 @@ router.get("/favorites", verifyJWT, updateToken, async (req, res) => {
   return res.json(favorites.map((val, i) => val.to_json(songs[i])));
 });
 
-router.post("/favorite/:songId", verifyJWT, async (req, res) => {
-  // TODO: Could possibly make sure that the songId is a valid spotify song id
-  let added = await Favorites.add_favorite(req.userId, req.params.songId);
+router.post("/favorite", verifyJWT, async (req: any, res) => {
+  /** Adds song to users favorite list
+   * Expects body in this form: {"song_id": string, "title": string, "artists": string, "song_url": string}
+   * Note that artists is expected to come in a comma separated list
+   * Only the song_id is required
+   * 
+   * @returns 200 if ok, 500 if fail
+   */
+  if (req.body.song_id === undefined) {
+    return res.status(400).send("Bad Request, Song_id missing");
+  }
+
+  let added = await Favorites.add_favorite(req.userId, req.body.song_id, req.body.title, req.body.artists, req.body.song_url);
   if (added) {
     res.status(200).send("Added!");
   } else {
@@ -165,7 +175,7 @@ router.post("/favorite/:songId", verifyJWT, async (req, res) => {
   }
 });
 
-router.delete("/favorite/:id", verifyJWT, async (req, res) => {
+router.delete("/favorite/:id", verifyJWT, async (req: any, res) => {
   let id;
   try {
     id = Number(req.params.id);


### PR DESCRIPTION
Reworked routes for adding and getting favorites. Here are the changes.

`POST /favorite` needs the `jwt-token` as a header, and also requires a body of `{"song_id": string, "title": string, "artists": string, "song_url": string}`. Only the `song_id` is required, if the rest is not supplied, it will simply be stored and returned as an empty string.

`GET /favorites` only needs the `jwt-token` as a header. It returns the following objects in a list: `{id: number, song_id: string, title: string, artists: string, song_url: string}`

Let me know if you would like any other changes!